### PR TITLE
Allow clients of the BasicPitch library to choose the tensorflow backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "@tensorflow/tfjs": "^4.22.0",
+    "@tensorflow/tfjs-backend-wasm": "^4.22.0",
     "@tonejs/midi": "^2.0.28"
   },
   "packageManager": "yarn@4.5.1+sha512.341db9396b6e289fecc30cd7ab3af65060e05ebff4b3b47547b278b9e67b08f485ecd8c79006b405446262142c7a38154445ef7f17c1d5d1de7d90bf9ce7054d"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playground-sessions/basic-pitch",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A JS module that takes audio and converts it to MIDI with machine learning",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/inference.test.ts
+++ b/src/inference.test.ts
@@ -196,7 +196,7 @@ test.each([
   const contours: number[][] = [];
   let pct: number = 0;
 
-  const basicPitch = new BasicPitch(model);
+  const basicPitch = await BasicPitch.init(model);
   // testing with an AudioBuffer as input
   await basicPitch.evaluateModel(
     audioBuffer as unknown as AudioBuffer,
@@ -268,7 +268,7 @@ test('Can correctly evaluate vocal 80 bpm data', async () => {
   const contours: number[][] = [];
   let pct: number = 0;
 
-  const basicPitch = new BasicPitch(`file://${__dirname}/../model/model.json`);
+  const basicPitch = await BasicPitch.init(`file://${__dirname}/../model/model.json`);
 
   const wavData = Array.from(Array(wavBuffer.length).keys()).map(
     key => wavBuffer._data[key],


### PR DESCRIPTION
AB#2380 - [Product Backlog Item 2380](https://dev.azure.com/playgroundsessions/Playground/_workitems/edit/2380): PD4 - Try WASM as the TensorFlow backend for BasicPitch

It should be about as speedy as the previous WebGL backend. We can also speed it up by enabling multithreading support as detailed in https://blog.tensorflow.org/2020/03/introducing-webassembly-backend-for-tensorflow-js.html